### PR TITLE
network byte order

### DIFF
--- a/lib/websocket/parser.rb
+++ b/lib/websocket/parser.rb
@@ -113,11 +113,11 @@ module WebSocket
 
     def read_extended_payload_length
       if message_size == :medium && @data.size >= 2
-        size = unpack_bytes(2,'S<')
+        size = unpack_bytes(2,'S>')
         ParserError.new("Wrong payload length. Expected to be greater than 125") unless size > 125
         size
       elsif message_size == :large && @data.size >= 4
-        size = unpack_bytes(8,'Q<')
+        size = unpack_bytes(8,'Q>')
          ParserError.new("Wrong payload length. Expected to be greater than 65535") unless size > 65_535
         size
       end

--- a/lib/websocket_parser.rb
+++ b/lib/websocket_parser.rb
@@ -53,9 +53,9 @@ module WebSocket
     format = 'CC'
 
     if payload_length > 65_535
-      format += 'Q<'
+      format += 'Q>'
     elsif payload_length > 125
-      format += 'S<'
+      format += 'S>'
     end
 
     if masked

--- a/spec/websocket/message_spec.rb
+++ b/spec/websocket/message_spec.rb
@@ -10,7 +10,7 @@ describe WebSocket::Message do
     # 2 bytes from header + 8 bytes from extended payload length + payload
     data.size.should == 2 + 8 + text.length
 
-    first_byte, second_byte, ext_length, payload = data.unpack("CCQ<a#{text.length}")
+    first_byte, second_byte, ext_length, payload = data.unpack("CCQ>a#{text.length}")
 
     first_byte.should  == 0b10000001 # Text frame with FIN bit set
     second_byte.should == 0b01111111 # Unmasked. Payload length 127.

--- a/spec/websocket/parser_spec.rb
+++ b/spec/websocket/parser_spec.rb
@@ -168,14 +168,14 @@ describe WebSocket::Parser do
 
     it "recognizes 256 bytes binary message in a single unmasked frame" do
       data = Array.new(256) { rand(256) }.pack('c*')
-      parser << [0x82, 0x7E, 0x0100].pack('CCS<') + data
+      parser << [0x82, 0x7E, 0x0100].pack('CCS>') + data
 
       received_messages.first.should == data
     end
 
     it "recoginzes 64KiB binary message in a single unmasked frame" do
       data = Array.new(65536) { rand(256) }.pack('c*')
-      parser << [0x82, 0x7F, 0x0000000000010000].pack('CCQ<') + data
+      parser << [0x82, 0x7F, 0x0000000000010000].pack('CCQ>') + data
 
       received_messages.first.should == data
     end


### PR DESCRIPTION
pack changed accordingly to rfc6455 section 5.2 :
 "Multibyte length quantities are expressed in network byte order"
