### PR TITLE
Ruby 2.0.0 support: Parser#append.

### DIFF
--- a/lib/websocket/parser.rb
+++ b/lib/websocket/parser.rb
@@ -55,6 +55,7 @@ module WebSocket
     # Stores the data in a buffer for later parsing
     def append(data)
       @data << data
+      @data.force_encoding("ASCII-8BIT")
     end
 
     # Receive data and parse it return an array of parsed messages


### PR DESCRIPTION
Due to (probably) Ruby's optimizations, `str1 << str2` could change
str1's encoding if str1 was blank.  It is critical to have @data in pure
ASCII and never allow UTF-8 there.
