### PR TITLE
Fix packing and unpacking for Ruby 1.9.2

### DIFF
--- a/lib/websocket/parser.rb
+++ b/lib/websocket/parser.rb
@@ -115,12 +115,12 @@ module WebSocket
 
     def read_extended_payload_length
       if message_size == :medium && @data.size >= 2
-        size = unpack_bytes(2,'S>')
+        size = unpack_bytes(2,'n')
         ParserError.new("Wrong payload length. Expected to be greater than 125") unless size > 125
         size
       elsif message_size == :large && @data.size >= 4
         size = unpack_bytes(8,'Q>')
-         ParserError.new("Wrong payload length. Expected to be greater than 65535") unless size > 65_535
+        ParserError.new("Wrong payload length. Expected to be greater than 65535") unless size > 65_535
         size
       end
     end

--- a/lib/websocket_parser.rb
+++ b/lib/websocket_parser.rb
@@ -55,7 +55,7 @@ module WebSocket
     if payload_length > 65_535
       format += 'Q>'
     elsif payload_length > 125
-      format += 'S>'
+      format += 'n'
     end
 
     if masked

--- a/spec/websocket/parser_spec.rb
+++ b/spec/websocket/parser_spec.rb
@@ -167,7 +167,7 @@ describe WebSocket::Parser do
 
     it "recognizes 256 bytes binary message in a single unmasked frame" do
       data = Array.new(256) { rand(256) }.pack('c*')
-      parser << [0x82, 0x7E, 0x0100].pack('CCS>') + data
+      parser << [0x82, 0x7E, 0x0100].pack('CCn') + data
 
       received_messages.first.should eq(data)
     end


### PR DESCRIPTION
'Q>' and 'S>' directives are not supported before Ruby 1.9.2, more details
at https://bugs.ruby-lang.org/issues/3491

This commit fixes packing and unpacking of messages between between 126
and 65,535 bytes, replacing 'S>' with 'n'.

Note that this error wasn't pointed out by specs because 'Q>' and S>'
directives are interpreted by Ruby 1.9.2 as 'Q' and 'S'.

For an implementation of the Ruby 1.9.2 version of 'Q>' see em-websocket:
https://github.com/igrigorik/em-websocket/blob/184977ba2fa1ee448ca3dac1f630573450ef2b31/lib/em-websocket/framing07.rb#L135
